### PR TITLE
BOOTLOADER BUGFIX: USART electrical coupling happens if there is no PULL...

### DIFF
--- a/src/peripherals/usart.c
+++ b/src/peripherals/usart.c
@@ -76,13 +76,13 @@ void usarts_setup(u32 ftdi_baud, u32 uarta_baud, u32 uartb_baud)
    * 3     PC10  PC11  UARTB
    */
 
-  gpio_mode_setup(GPIOC, GPIO_MODE_AF, GPIO_PUPD_NONE, GPIO6 | GPIO7);
+  gpio_mode_setup(GPIOC, GPIO_MODE_AF, GPIO_PUPD_PULLUP, GPIO6 | GPIO7);
   gpio_set_af(GPIOC, GPIO_AF8, GPIO6 | GPIO7);
 
-  gpio_mode_setup(GPIOA, GPIO_MODE_AF, GPIO_PUPD_NONE, GPIO9 | GPIO10);
+  gpio_mode_setup(GPIOA, GPIO_MODE_AF, GPIO_PUPD_PULLUP, GPIO9 | GPIO10);
   gpio_set_af(GPIOA, GPIO_AF7, GPIO9 | GPIO10);
 
-  gpio_mode_setup(GPIOC, GPIO_MODE_AF, GPIO_PUPD_NONE, GPIO10 | GPIO11);
+  gpio_mode_setup(GPIOC, GPIO_MODE_AF, GPIO_PUPD_PULLUP, GPIO10 | GPIO11);
   gpio_set_af(GPIOC, GPIO_AF7, GPIO10 | GPIO11);
 
   usart_set_parameters(USART6, ftdi_baud);


### PR DESCRIPTION
...-UP resistor. Without this, a bootloader bug manifests itself as a sent handshake being received on the same UART and trappedin the receive_handshake_callback
